### PR TITLE
FOOTCOORDSの無効化(archiveブランチ)

### DIFF
--- a/hrpsys_choreonoid_tutorials/launch/jaxon_red_choreonoid.launch
+++ b/hrpsys_choreonoid_tutorials/launch/jaxon_red_choreonoid.launch
@@ -13,7 +13,7 @@
   <arg name="GUI" default="true" />
   <arg name="hrpsys_precreate_rtc" default=""/>
   <arg name="hrpsys_opt_rtc_config_args" default="" />
-  <arg name="LAUNCH_FOOTCOORDS" default="true" />
+  <arg name="LAUNCH_FOOTCOORDS" default="false" />
 
   <!-- robot dependant settings -->
   <arg if="$(arg LOAD_OBJECTS)"


### PR DESCRIPTION
現状FOOTCOORDSを使っていないことから、jsk_controlへの依存をなくすために無効化しました。