### PR TITLE
[jaxon_red_setup.py][jaxon_red_rh_setup.py] do not set error limit to motor_joint (multisense)

### DIFF
--- a/hrpsys_choreonoid_tutorials/scripts/jaxon_blue_rh_setup.py
+++ b/hrpsys_choreonoid_tutorials/scripts/jaxon_blue_rh_setup.py
@@ -42,7 +42,6 @@ class JAXON_BLUE_HrpsysConfigurator(ChoreonoidHrpsysConfigurator):
 
     def startABSTIMP (self):
         ### not used on hrpsys
-        # self.el_svc.setServoErrorLimit("motor_joint",   sys.float_info.max)
         # self.el_svc.setServoErrorLimit("RARM_F_JOINT0", sys.float_info.max)
         # self.el_svc.setServoErrorLimit("RARM_F_JOINT1", sys.float_info.max)
         # self.el_svc.setServoErrorLimit("LARM_F_JOINT0", sys.float_info.max)

--- a/hrpsys_choreonoid_tutorials/scripts/jaxon_red_rh_setup.py
+++ b/hrpsys_choreonoid_tutorials/scripts/jaxon_red_rh_setup.py
@@ -42,7 +42,6 @@ class JAXON_RED_HrpsysConfigurator(ChoreonoidHrpsysConfigurator):
 
     def startABSTIMP (self):
         ### not used on hrpsys
-        self.el_svc.setServoErrorLimit("motor_joint",   sys.float_info.max)
         self.el_svc.setServoErrorLimit("RARM_F_JOINT0", sys.float_info.max)
         self.el_svc.setServoErrorLimit("RARM_F_JOINT1", sys.float_info.max)
         self.el_svc.setServoErrorLimit("LARM_F_JOINT0", sys.float_info.max)

--- a/hrpsys_choreonoid_tutorials/scripts/jaxon_red_setup.py
+++ b/hrpsys_choreonoid_tutorials/scripts/jaxon_red_setup.py
@@ -42,7 +42,6 @@ class JAXON_RED_HrpsysConfigurator(ChoreonoidHrpsysConfiguratorOrg):
 
     def startABSTIMP (self):
         ### not used on hrpsys
-        self.el_svc.setServoErrorLimit("motor_joint",   sys.float_info.max)
         self.el_svc.setServoErrorLimit("RARM_F_JOINT0", sys.float_info.max)
         self.el_svc.setServoErrorLimit("RARM_F_JOINT1", sys.float_info.max)
         self.el_svc.setServoErrorLimit("LARM_F_JOINT0", sys.float_info.max)


### PR DESCRIPTION
https://github.com/start-jsk/rtmros_choreonoid/pull/365
と同じ変更です